### PR TITLE
Update LllbinParseInfo.cs

### DIFF
--- a/NetCore8583/Parse/LllbinParseInfo.cs
+++ b/NetCore8583/Parse/LllbinParseInfo.cs
@@ -29,7 +29,7 @@ namespace NetCore8583.Parse
             var binval = l == 0
                 ? new sbyte[0]
                 : HexCodec.HexDecode(buf.BytesToString(pos + 3,
-                    l,
+                    l * 2,
                     Encoding.Default));
             
             if (custom == null)
@@ -63,7 +63,7 @@ namespace NetCore8583.Parse
                 var dec = custom.DecodeField(l == 0
                     ? ""
                     : buf.BytesToString(pos + 3,
-                        l,
+                        l * 2,
                         Encoding.Default));
                 return dec == null
                     ? new IsoValue(IsoType,


### PR DESCRIPTION
Data length error for IsoType: LLLBIN. When value as LLLBIN is being parsed, value is parsed with the wrong length.