### PR TITLE
chore: add net9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
             6.x
             7.x
             8.x
+            9.x
           dotnet-quality: 'ga'
       - name: Restore
         run: dotnet restore

--- a/NetCore8583.Test/NetCore8583.Test.csproj
+++ b/NetCore8583.Test/NetCore8583.Test.csproj
@@ -4,7 +4,7 @@
 
     <IsPackable>false</IsPackable>
 
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <ReleaseVersion>1.1.0</ReleaseVersion>
   </PropertyGroup>
 
@@ -16,8 +16,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="TimeZoneConverter" Version="6.1.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
@@ -25,6 +24,15 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'"
+      Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+
+    <!-- Version 9 is not tested for dotnet 7 and below and building will produce 'use at your own risk' warning -->
+    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'"
+      Include="System.Text.Encoding.CodePages" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NetCore8583/NetCore8583.csproj
+++ b/NetCore8583/NetCore8583.csproj
@@ -5,17 +5,24 @@
     <Description>NetCore8583 is a library that helps parse/read and generate ISO 8583 messages. It does not handle sending or reading them over a network connection, but it does parse the data you have read and can generate the data you need to write over a network connection.</Description>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseUrl>https://opensource.org/licenses/MIT</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/Tochemey/NetCore8583</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Tochemey/NetCore8583</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageTags>Iso8583 NetCore Banking C#</PackageTags>
     <Copyright>Tochemey 2018-2024</Copyright>
     <PackageVersion>2.2.1</PackageVersion>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <ReleaseVersion>2.2.0</ReleaseVersion>
     <Title>NetCore8583</Title>
   </PropertyGroup>
+
+  <PropertyGroup>
+      <PackageLicenseFile>LICENSE</PackageLicenseFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <None Include="../LICENSE" Pack="true" PackagePath="" Link="LICENSE"/>
+  </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -29,7 +36,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+    <PackageReference Condition="'$(TargetFramework)' == 'net6.0' OR '$(TargetFramework)' == 'net7.0' OR '$(TargetFramework)' == 'net8.0'"
+      Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+
+    <!-- Version 9 is not tested for dotnet 7 and below and will building will produce 'use at your own risk' warning -->
+    <PackageReference Condition="'$(TargetFramework)' == 'net9.0'"
+      Include="System.Text.Encoding.CodePages" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
System.Text.Encoding.CodePages v9 stopped supporting dotnet 7 and below, this change uses v9 when dotnet 8 or above are used to build the project.

Replaced deprecated PackageLicenseUrl tag with PackageLicenseFile which references the existing License file

closes #33 